### PR TITLE
Added retrieve method for recipe view

### DIFF
--- a/tastevineapi/views/recipe_view.py
+++ b/tastevineapi/views/recipe_view.py
@@ -14,7 +14,7 @@ class RecipeView(ViewSet):
         """Handle GET requests for all recipes
 
         Returns:
-            Response -- JSON serialized array
+            Response -- JSON serialized list of recipes
         """
 
         owner_only = self.request.query_params.get("owner", None)
@@ -28,6 +28,19 @@ class RecipeView(ViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as ex:
             return HttpResponseServerError(ex)
+        
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single recipe
+
+        Returns:
+            Response -- JSON serialized recipe record
+        """
+        try:
+            recipe = Recipe.objects.get(pk=pk)
+            serializer = RecipeSerializer(recipe)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return Response({"reason": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class RecipeSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
I added a retrieve method on Recipe View

Supported routes
`/recipes/n=current` for a GET request will return a single recipe object

## Steps to test
1. Pull down the `ts-recipe-retrieve` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Use this token in the header:
```
Token c29b168a0c1e461b3ff36dd9ce15e6e1d1768597
```
5. Perform a GET to `http://localhost:8000/recipes/1` and make sure you receive a similar lookin response body with only two objects:
```
[
    {
        "id": 1,
        "title": "Pumpkin Coffee Cake",
        "author": 1,
        "publication_date": "2023-10-16",
        "image": null,
        "instructions": "Preheat oven to 350 degrees | Combine wet ingredients (pumpkin puree, 1/2 C brown sugar, canola oil, 
        maple syrup, and whole milk) in a bowl | In a separate bowl combine dry ingredients (2 C flour, baking soda, baking 
        powder, salt, 2 tsp cinnamon, nutmeg, cloves, and ground ginger) | In another bowl mix crumble topping ingredients with 
        a pastry cutter (1/2 C flour, 1/2 packed brown sugar, 1 1/2 tsp cinnamon, and cold diced butter | Slowly add dry 
        ingredients to wet ingredients with a whisk until well incorporated | Spray down a 9x9 baking pan and then add all of the 
        batter, spreading evenly | Top with all of the crumble mixture | Bake for 30-35 minutes until a toothpick comes out clean. ",
        "ingredients": [
            {
                "name": "pumpkin puree"
            },
            {
                "name": "brown sugar"
            },
            ...
        ],
        "categories": [
            {
                "label": "Breakfast"
            },
            {
                "label": "Desserts"
            }
        ]
    }
]
```
6. Should receive a 200 status