### PR TITLE
Added list method to ingredients view

### DIFF
--- a/tastevineapi/views/__init__.py
+++ b/tastevineapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .auth import register_user, login_user
 from .recipe_view import RecipeView
+from .ingredient_view import IngredientView

--- a/tastevineapi/views/ingredient_view.py
+++ b/tastevineapi/views/ingredient_view.py
@@ -1,4 +1,7 @@
-from rest_framework import serializers
+from django.http import HttpResponseServerError
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
 from tastevineapi.models import Ingredient
 
 class IngredientSerializer(serializers.ModelSerializer):
@@ -6,4 +9,21 @@ class IngredientSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Ingredient
-        fields = ('name',)
+        fields = ('id', 'name',)
+
+
+class IngredientView(ViewSet):
+    """Ingredient view set"""
+
+    def list(self, request):
+        """Handle GET requests for all ingredients
+
+        Returns:
+            Response -- JSON serialized list of ingredients
+        """
+        try:
+            ingredients = Ingredient.objects.all()
+            serializer = IngredientSerializer(ingredients, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return HttpResponseServerError(ex)

--- a/tastevineproject/urls.py
+++ b/tastevineproject/urls.py
@@ -1,9 +1,10 @@
 from django.urls import include, path
 from rest_framework import routers
-from tastevineapi.views import register_user, login_user, RecipeView
+from tastevineapi.views import register_user, login_user, RecipeView, IngredientView
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"recipes", RecipeView, "recipe")
+router.register(r"ingredients", IngredientView, "ingredient")
 
 
 urlpatterns = [


### PR DESCRIPTION
I added a list method and serializer to Ingredient View

Supported routes
`/ingredients` for a GET request will return an array of ingredient objects

## Steps to test
1. Pull down the `ts-list-ingredients` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Use this token in the header:
```
Token c29b168a0c1e461b3ff36dd9ce15e6e1d1768597
```
5. Perform a GET to `http://localhost:8000/ingredients` and make sure you receive a similar lookin response body:
```
[
    {
        "id": 1,
        "name": "pumpkin puree"
    },
    {
        "id": 2,
        "name": "brown sugar"
    },
    {
        "id": 3,
        "name": "canola oil"
    },
    ...
```
6. Make sure the status code is a 200